### PR TITLE
Fragmente-Scanner

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -24,3 +24,7 @@ if (rex::isBackend() && rex::getUser()) {
     rex_extension::register('CLANG_ADDED', 'Alexplusde\Wildcard\Wildcard::addClangColumn');
     rex_extension::register('CLANG_DELETED', 'Alexplusde\Wildcard\Wildcard::removeClangColumn');
 }
+
+if(rex::isDebugMode() && rex_addon::get('developer')->isAvailable()) {
+    FragmentsScanner::scan();
+}

--- a/boot.php
+++ b/boot.php
@@ -25,6 +25,6 @@ if (rex::isBackend() && rex::getUser()) {
     rex_extension::register('CLANG_DELETED', 'Alexplusde\Wildcard\Wildcard::removeClangColumn');
 }
 
-if(rex::isDebugMode() && rex_addon::get('developer')->isAvailable()) {
+if (rex::isDebugMode() && rex_addon::get('developer')->isAvailable()) {
     FragmentsScanner::scan();
 }

--- a/lib/FragmentScanner.php
+++ b/lib/FragmentScanner.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace Alexplusde\Wildcard;
+
+class FragmentsScanner
+{
+    /**
+     * @var string
+     */
+    private $addonDir;
+
+    /**
+     * @var string
+     */
+    private $wildcardFile;
+
+    /**
+     * @var array
+     */
+    private $wildcardContent;
+
+    /**
+     * FragmentsScanner constructor.
+     *
+     * @param string $addonDir
+     */
+    public function __construct(string $addonDir)
+    {
+        $this->addonDir = $addonDir;
+        $this->wildcardFile = $this->addonDir . '/wildcard/translations.json';
+        $this->ensureWildcardFileExists();
+        $this->wildcardContent = $this->getWildcardContent();
+    }
+
+    /**
+     * Liefert alle Fragment-Dateien, die Platzhalter enthalten könnten.
+     *
+     * @return array
+     */
+    public function getFiles(): array
+    {
+        return glob($this->addonDir . '/fragments/**/*.php', GLOB_BRACE);
+    }
+
+    /**
+     * Erstellt die Wildcard-Datei, wenn sie nicht existiert.
+     */
+    private function ensureWildcardFileExists(): void
+    {
+        if (!file_exists($this->wildcardFile)) {
+            file_put_contents($this->wildcardFile, json_encode(['wildcards' => []], JSON_PRETTY_PRINT));
+        }
+    }
+
+    /**
+     * Gibt den Inhalt der Wildcard-Datei als PHP-Array zurück.
+     *
+     * @return array
+     */
+    private function getWildcardContent(): array
+    {
+        return json_decode(file_get_contents($this->wildcardFile), true);
+    }
+
+    /**
+     * Überprüft, ob der Key bereits in Wildcard vorhanden ist.
+     *
+     * @param string $key
+     * @return bool
+     */
+    public function keyExists(string $key): bool
+    {
+        return array_key_exists($key, $this->wildcardContent['wildcards']);
+    }
+
+    /**
+     * Fügt den Key zu den Wildcards hinzu.
+     *
+     * @param string $key
+     */
+    public function addKey(string $key): void
+    {
+        if (!$this->keyExists($key)) {
+            $this->wildcardContent['wildcards'][$key] = [
+                'timestamp' => date('Y-m-d H:i:s'),
+                'translations' => []
+            ];
+        }
+    }
+
+    /**
+     * Schreibt die Wildcard-Datei in das zugehörige Addon-Verzeichnis.
+     */
+    public function writeWildcardFile(): void
+    {
+        file_put_contents($this->wildcardFile, json_encode($this->wildcardContent, JSON_PRETTY_PRINT));
+    }
+
+    /**
+     * Führt die Scan-Funktion für alle Addons oder ein spezifisches Addon aus und aktualisiert die Wildcard-Dateien.
+     *
+     * @param string $dir
+     */
+    public static function scan(string $dir = '/www/redaxo/src/addons/*'): void
+    {
+        $directories = glob($dir, GLOB_ONLYDIR | GLOB_BRACE);
+
+        foreach ($directories as $dir) {
+            $scanner = new FragmentsScanner($dir);
+            $files = $scanner->getFiles();
+            foreach ($files as $file) {
+                $content = file_get_contents($file);
+                preg_match_all('/{{(.*?)}}/', $content, $matches);
+                $keys = $matches[1];
+                foreach ($keys as $key) {
+                    $scanner->addKey($key);
+                }
+            }
+            $scanner->writeWildcardFile();
+        }
+    }
+}

--- a/lib/FragmentScanner.php
+++ b/lib/FragmentScanner.php
@@ -5,44 +5,40 @@ namespace Alexplusde\Wildcard;
 use rex_file;
 use rex_path;
 
+use function array_key_exists;
+
+use const DIRECTORY_SEPARATOR;
+use const GLOB_BRACE;
+use const JSON_PRETTY_PRINT;
+
 class FragmentScanner
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     private $packageDir;
-    /**
-     * @var string
-     */
+    /** @var string */
     private $wildcardFile;
 
-    /**
-     * @var array
-     */
+    /** @var array */
     private $wildcardContent;
 
     /**
      * FragmentScanner constructor.
-     *
-     * @param string $packageName
      */
     public function __construct(string $packageDir)
     {
         $this->packageDir = $packageDir;
-        $this->wildcardFile = $packageDir . 'wildcard'.\DIRECTORY_SEPARATOR.'translations.json';
+        $this->wildcardFile = $packageDir . 'wildcard' . DIRECTORY_SEPARATOR . 'translations.json';
         $this->wildcardContent = $this->getWildcardContent();
     }
 
     /**
      * Liefert alle Fragment-Dateien, die Platzhalter enthalten könnten.
-     *
-     * @return array
      */
     public function getFiles(): array
     {
         return array_merge(
-            glob($this->packageDir . 'fragments' . \DIRECTORY_SEPARATOR . '*.php', GLOB_BRACE),
-            glob($this->packageDir . 'fragments' . \DIRECTORY_SEPARATOR . '**' . \DIRECTORY_SEPARATOR . '*.php', GLOB_BRACE)
+            glob($this->packageDir . 'fragments' . DIRECTORY_SEPARATOR . '*.php', GLOB_BRACE),
+            glob($this->packageDir . 'fragments' . DIRECTORY_SEPARATOR . '**' . DIRECTORY_SEPARATOR . '*.php', GLOB_BRACE),
         );
     }
 
@@ -58,8 +54,6 @@ class FragmentScanner
 
     /**
      * Gibt den Inhalt der Wildcard-Datei als PHP-Array zurück.
-     *
-     * @return array
      */
     private function getWildcardContent(): ?array
     {
@@ -68,13 +62,10 @@ class FragmentScanner
 
     /**
      * Überprüft, ob der Key bereits in Wildcard vorhanden ist.
-     *
-     * @param string $key
-     * @return bool
      */
     public function keyExists(string $key): bool
     {
-        if(!isset($this->wildcardContent['wildcards'])) {
+        if (!isset($this->wildcardContent['wildcards'])) {
             return false;
         }
         return array_key_exists($key, $this->wildcardContent['wildcards']);
@@ -82,15 +73,13 @@ class FragmentScanner
 
     /**
      * Fügt den Key zu den Wildcards hinzu.
-     *
-     * @param string $key
      */
     public function addKey(string $key): void
     {
         if (!$this->keyExists($key)) {
             $this->wildcardContent['wildcards'][$key] = [
                 'timestamp' => date('Y-m-d H:i:s'),
-                'translations' => []
+                'translations' => [],
             ];
         }
     }
@@ -106,18 +95,16 @@ class FragmentScanner
 
     /**
      * Führt die Scan-Funktion für alle Addons oder ein spezifisches Addon aus und aktualisiert die Wildcard-Dateien.
-     *
-     * @param string $dir
      */
-    public static function scan(string $packageName = null): void
+    public static function scan(?string $packageName = null): void
     {
         $dirs = glob(rex_path::addon('*'));
-        if($packageName) {
+        if ($packageName) {
             $dirs = [rex_path::addon($packageName)];
         }
 
         foreach ($dirs as $dir) {
-            $scanner = new FragmentScanner($dir);
+            $scanner = new self($dir);
             $files = $scanner->getFiles();
             foreach ($files as $file) {
                 $content = rex_file::get($file);

--- a/lib/FragmentScanner.php
+++ b/lib/FragmentScanner.php
@@ -2,27 +2,25 @@
 
 namespace Alexplusde\Wildcard;
 
+use function array_key_exists;
+
+use const GLOB_BRACE;
+use const GLOB_ONLYDIR;
+use const JSON_PRETTY_PRINT;
+
 class FragmentsScanner
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     private $addonDir;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     private $wildcardFile;
 
-    /**
-     * @var array
-     */
+    /** @var array */
     private $wildcardContent;
 
     /**
      * FragmentsScanner constructor.
-     *
-     * @param string $addonDir
      */
     public function __construct(string $addonDir)
     {
@@ -34,8 +32,6 @@ class FragmentsScanner
 
     /**
      * Liefert alle Fragment-Dateien, die Platzhalter enthalten könnten.
-     *
-     * @return array
      */
     public function getFiles(): array
     {
@@ -54,8 +50,6 @@ class FragmentsScanner
 
     /**
      * Gibt den Inhalt der Wildcard-Datei als PHP-Array zurück.
-     *
-     * @return array
      */
     private function getWildcardContent(): array
     {
@@ -64,9 +58,6 @@ class FragmentsScanner
 
     /**
      * Überprüft, ob der Key bereits in Wildcard vorhanden ist.
-     *
-     * @param string $key
-     * @return bool
      */
     public function keyExists(string $key): bool
     {
@@ -75,15 +66,13 @@ class FragmentsScanner
 
     /**
      * Fügt den Key zu den Wildcards hinzu.
-     *
-     * @param string $key
      */
     public function addKey(string $key): void
     {
         if (!$this->keyExists($key)) {
             $this->wildcardContent['wildcards'][$key] = [
                 'timestamp' => date('Y-m-d H:i:s'),
-                'translations' => []
+                'translations' => [],
             ];
         }
     }
@@ -98,15 +87,13 @@ class FragmentsScanner
 
     /**
      * Führt die Scan-Funktion für alle Addons oder ein spezifisches Addon aus und aktualisiert die Wildcard-Dateien.
-     *
-     * @param string $dir
      */
     public static function scan(string $dir = '/www/redaxo/src/addons/*'): void
     {
         $directories = glob($dir, GLOB_ONLYDIR | GLOB_BRACE);
 
         foreach ($directories as $dir) {
-            $scanner = new FragmentsScanner($dir);
+            $scanner = new self($dir);
             $files = $scanner->getFiles();
             foreach ($files as $file) {
                 $content = file_get_contents($file);


### PR DESCRIPTION
afffects #1 

Scannt alle Fragmente des Projekts oder eines Addons auf Platzhalter nach dem Schema `{{.*}}` und ergänzt diese im zugehörigen Addon

